### PR TITLE
fix: pass correct theme stream to avatar dropdown

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -203,7 +203,11 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   const showModalStream = new Stream(false);
   const userAvatarStream = new Stream('doc.webp');
-  const userAvatar = avatarDropdown(userAvatarStream, { width: '50px', height: '50px', rounded: true }, themeStream = currentTheme, [
+  const userAvatar = avatarDropdown(
+    userAvatarStream,
+    { width: '50px', height: '50px', rounded: true },
+    currentTheme,
+    [
     { label: 'Profile', onClick: () => showToast('Profile clicked') },
     { 
   label: 'Settings', 


### PR DESCRIPTION
## Summary
- fix crash when loading app by passing currentTheme to avatar dropdown

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689278ac272483288a3d633f75f74eac