### PR TITLE
Ensure metadata files include summary field

### DIFF
--- a/js/uploadFormContainer.js
+++ b/js/uploadFormContainer.js
@@ -71,10 +71,8 @@ async function createMetadataFile(slug, title, filePath, summary) {
     const metadata = {
         title: title,
         path: filePath,
+        summary: summary || "",
     };
-    if (summary) {
-        metadata.summary = summary;
-    }
     console.log("Creating metadata file with:", metadata);
     const metadataContent = btoa(JSON.stringify(metadata, null, 2));
     const metadataFilePath = `${repoPath}/meta/${slug}.json`;


### PR DESCRIPTION
## Summary
- Always include a `summary` property when creating metadata files so the summary is visible even if empty.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6892838a19a083289891a4dce940d107