### PR TITLE
Fix summary auth and expand state parsing

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -16,6 +16,7 @@ function settingsModal(showModalStream, themeStream = currentTheme) {
   const repoOwner = localStorage.getItem('repoOwner') || '';
   const repoName = localStorage.getItem('repoName') || '';
   const repoPath = localStorage.getItem('repoPath') || '';
+  const huggingFaceTokenEncoded = localStorage.getItem('huggingFaceToken') || '';
 
   // Streams for form data with initial values
   const githubUsernameStream = new Stream(githubUsername);
@@ -23,6 +24,7 @@ function settingsModal(showModalStream, themeStream = currentTheme) {
   const repoOwnerStream = new Stream(repoOwner);
   const repoNameStream = new Stream(repoName);
   const repoPathStream = new Stream(repoPath);
+  const huggingFaceTokenStream = new Stream(base64Decode(huggingFaceTokenEncoded));
 
   return conditional(showModalStream, () => {
     // Create overlay
@@ -68,6 +70,7 @@ function settingsModal(showModalStream, themeStream = currentTheme) {
       editText(repoOwnerStream, { placeholder: 'Repository Owner', margin: '0.5rem 0' }, themeStream),
       editText(repoNameStream, { placeholder: 'Repository Name', margin: '0.5rem 0' }, themeStream),
       editText(repoPathStream, { placeholder: 'Repository Path', margin: '0.5rem 0' }, themeStream),
+      editText(huggingFaceTokenStream, { placeholder: 'Hugging Face Token', margin: '0.5rem 0', type: 'password' }, themeStream),
       (() => {
         const isSaving = new Stream(false);
         const saveLabel = derived(isSaving, val => val ? "Saving..." : "Save");
@@ -78,6 +81,7 @@ function settingsModal(showModalStream, themeStream = currentTheme) {
 
           // Encode the GitHub token before saving
           const githubTokenEncoded = base64Encode(githubTokenStream.get());
+          const huggingFaceTokenEncoded = base64Encode(huggingFaceTokenStream.get());
 
           // Save to localStorage
           localStorage.setItem('githubUsername', githubUsernameStream.get());
@@ -85,6 +89,7 @@ function settingsModal(showModalStream, themeStream = currentTheme) {
           localStorage.setItem('repoOwner', repoOwnerStream.get());
           localStorage.setItem('repoName', repoNameStream.get());
           localStorage.setItem('repoPath', repoPathStream.get());
+          localStorage.setItem('huggingFaceToken', huggingFaceTokenEncoded);
 
           // Close modal after saving
           showModalStream.set(false);
@@ -175,8 +180,10 @@ document.addEventListener('DOMContentLoaded', async () => {
   repoOwner = localStorage.getItem('repoOwner');
   repoName = localStorage.getItem('repoName');
   repoPath = localStorage.getItem('repoPath');
+  huggingFaceTokenEncoded = localStorage.getItem('huggingFaceToken');
 
   githubToken = base64Decode(githubTokenEncoded);
+  huggingFaceToken = base64Decode(huggingFaceTokenEncoded || '');
 
   await ensureDirectoriesExist();
 

--- a/js/components/elements.js
+++ b/js/components/elements.js
@@ -522,22 +522,15 @@ function groupedDocumentGrid(documentsStream, expandedStream, themeStream = curr
 
   wrapper.appendChild(searchInput);
 
-    // Restore expanded state from localStorage if available
-const savedExpanded = localStorage.getItem('docGroupsExpanded');
-if (savedExpanded) {
-  try {
-    const parsedExpanded = JSON.parse(savedExpanded);
-    expandedStream.set(parsedExpanded);
-
-    // Then update it
-    localStorage.setItem('docGroupsExpanded', JSON.stringify({ 
-      ...parsedExpanded, 
-      [category]: !userExpanded 
-    }));
-  } catch (e) {
-    console.warn('Failed to parse saved expanded state:', e);
+  // Restore expanded state from localStorage if available
+  const savedExpanded = localStorage.getItem('docGroupsExpanded');
+  if (savedExpanded) {
+    try {
+      expandedStream.set(JSON.parse(savedExpanded));
+    } catch (e) {
+      console.warn('Failed to parse saved expanded state:', e);
+    }
   }
-}
 
 
 // Control bar with icon buttons

--- a/js/uploadFormContainer.js
+++ b/js/uploadFormContainer.js
@@ -5,6 +5,8 @@ var githubToken = '';
 var repoOwner = '';
 var repoName = '';
 var repoPath = '';
+var huggingFaceTokenEncoded = '';
+var huggingFaceToken = '';
 
 
 // Base64 encode function (obfuscation)
@@ -19,12 +21,17 @@ function base64Decode(str) {
 
 // === Hugging Face summarization ===
 async function summarizeText(text) {
+    if (!huggingFaceToken) {
+        console.warn('Hugging Face token not set; skipping summary');
+        return '';
+    }
     try {
         // Using Hugging Face's BART model via summarization pipeline
         const response = await fetch('https://api-inference.huggingface.co/models/facebook/bart-large-cnn', {
             method: 'POST',
             headers: {
-                'Content-Type': 'application/json'
+                'Content-Type': 'application/json',
+                'Authorization': `Bearer ${huggingFaceToken}`
             },
             body: JSON.stringify({ inputs: text })
         });


### PR DESCRIPTION
## Summary
- add Hugging Face token support so summaries include authorization and skip when unset
- persist Hugging Face token via settings modal and load it at startup
- fix grouped document grid initialisation by safely parsing saved expansion state

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68933451e540832883f19b0c76cbb937