### PR TITLE
Wrap summary text across multiple lines

### DIFF
--- a/js/components/elements.js
+++ b/js/components/elements.js
@@ -723,7 +723,12 @@ wrapper.appendChild(contentWrapper);
             td.style.border = `1px solid ${colors.border}`;
             td.style.fontFamily = fonts.base;
             td.style.color = colors.foreground;
-            td.style.whiteSpace = 'nowrap';
+            if (key === 'summary') {
+              td.style.whiteSpace = 'pre-wrap';
+              td.style.wordBreak = 'break-word';
+            } else {
+              td.style.whiteSpace = 'nowrap';
+            }
             row.appendChild(td);
           });
           tbody.appendChild(row);


### PR DESCRIPTION
## Summary
- allow groupedDocumentGrid summary field to wrap by enabling pre-wrap and break-word styles

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6893760aeb148328a1c9b689d9e51f98