### PR TITLE
Fix Unicode handling in base64 metadata encoding

### DIFF
--- a/js/uploadFormContainer.js
+++ b/js/uploadFormContainer.js
@@ -116,7 +116,7 @@ async function createMetadataFile(slug, title, filePath, summary) {
         summary: summary || "",
     };
     console.log("Creating metadata file with:", metadata);
-    const metadataContent = btoa(JSON.stringify(metadata, null, 2));
+    const metadataContent = base64Encode(JSON.stringify(metadata, null, 2));
     const metadataFilePath = `${repoPath}/meta/${slug}.json`;
 
     await fetch(`https://api.github.com/repos/${repoOwner}/${repoName}/contents/${metadataFilePath}`, {
@@ -145,7 +145,7 @@ async function fetchDocumentIndexFromGitHub() {
   }
 
   const result = await response.json();
-  const decodedContent = atob(result.content);
+  const decodedContent = base64Decode(result.content);
   const index = JSON.parse(decodedContent);
 
   // Enrich each document with its summary from meta files
@@ -159,7 +159,7 @@ async function fetchDocumentIndexFromGitHub() {
       });
       if (metaResponse.ok) {
         const metaResult = await metaResponse.json();
-        const metaDecoded = atob(metaResult.content);
+        const metaDecoded = base64Decode(metaResult.content);
         const metaData = JSON.parse(metaDecoded);
         doc.summary = metaData.summary || '';
       } else {
@@ -185,7 +185,7 @@ async function fetchDocumentIndex() {
   });
   const data = await response.json();
   if (data.content) {
-    const decodedData = atob(data.content);  // Decoding from base64
+    const decodedData = base64Decode(data.content);  // Decoding from base64
     return JSON.parse(decodedData);
   }
   return [];
@@ -266,7 +266,7 @@ async function updateDocumentIndex(newDoc) {
     if (response.ok) {
       const data = await response.json();
       sha = data.sha; // Required for updating
-      const decoded = atob(data.content);
+      const decoded = base64Decode(data.content);
       existingIndex = JSON.parse(decoded);
     }
   } catch (err) {
@@ -282,7 +282,7 @@ async function updateDocumentIndex(newDoc) {
   }
 
   // Step 3: Upload updated index
-  const updatedContent = btoa(JSON.stringify(existingIndex, null, 2));
+  const updatedContent = base64Encode(JSON.stringify(existingIndex, null, 2));
 
   const putResponse = await fetch(`https://api.github.com/repos/${repoOwner}/${repoName}/contents/${filePath}`, {
     method: 'PUT',


### PR DESCRIPTION
## Summary
- Encode metadata and index JSON with `base64Encode` to avoid Latin1 `btoa` errors
- Decode GitHub metadata using `base64Decode` for correct Unicode handling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68937bccb2e48328b5a99924737f0d14