### PR TITLE
feat: improve table headers for grid views

### DIFF
--- a/css/theme.css
+++ b/css/theme.css
@@ -10,3 +10,20 @@ input {
   border: 1px solid #444;
   border-radius: 4px;
 }
+
+.table-header {
+  font-size: 1rem;
+  font-weight: bold;
+  background-color: #333;
+  color: #fff;
+  font-family: sans-serif;
+  text-align: left;
+  padding: 0.5rem 1rem;
+  white-space: nowrap;
+  border: 1px solid #444;
+}
+
+.table-header-sticky {
+  position: sticky;
+  top: 0;
+}

--- a/js/components/elements.js
+++ b/js/components/elements.js
@@ -2,6 +2,12 @@ function text(str) {
   return document.createTextNode(str);
 }
 
+function keyToTitle(key) {
+  return key
+    .replace(/_/g, ' ')
+    .replace(/\w\S*/g, w => w.charAt(0).toUpperCase() + w.slice(1));
+}
+
 function reactiveElement(stream, renderFn = v => v) {
   const placeholder = document.createElement('div');
 
@@ -644,15 +650,8 @@ wrapper.appendChild(contentWrapper);
       const headRow = document.createElement('tr');
       keys.forEach(key => {
         const th = document.createElement('th');
-        th.textContent = key.toUpperCase();
-        th.style.padding = '0.5rem 1rem';
-        th.style.fontFamily = fonts.base;
-        th.style.fontWeight = 'bold';
-        th.style.backgroundColor = colors.surface;
-        th.style.color = colors.foreground;
-        th.style.border = `1px solid ${colors.border}`;
-        th.style.textAlign = 'left';
-        th.style.whiteSpace = 'nowrap';
+        th.textContent = keyToTitle(key);
+        th.classList.add('table-header', 'table-header-sticky');
         headRow.appendChild(th);
       });
       thead.appendChild(headRow);
@@ -771,15 +770,8 @@ function gridView(dataStream, options = {}, themeStream = currentTheme) {
     const headRow = document.createElement('tr');
     keys.forEach(key => {
       const th = document.createElement('th');
-      th.textContent = key === 'download' ? '' : key.toUpperCase();
-      th.style.padding = '0.5rem 1rem';
-      th.style.fontFamily = fonts.base;
-      th.style.fontWeight = 'bold';
-      th.style.backgroundColor = colors.surface;
-      th.style.color = colors.foreground;
-      th.style.borderRight = `1px solid ${colors.border}`;
-      th.style.whiteSpace = 'nowrap';
-      th.style.textAlign = 'left'; // ✅ Left-align header text
+      th.textContent = key === 'download' ? '' : keyToTitle(key);
+      th.classList.add('table-header', 'table-header-sticky');
       headRow.appendChild(th);
     });
 


### PR DESCRIPTION
## Summary
- add helper to convert data keys to human readable titles
- style table headers with new reusable CSS classes
- apply header classes to document and grid views

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68939ae288f48328b985e048a52731d7