### PR TITLE
fix: prevent recursion in isSystemUser check

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -4,7 +4,7 @@ const expandedCategories = new Stream({});
 
 // Simple system user check using localStorage or external hook
 function isSystemUser() {
-  if (typeof window.isSystemUser === 'function') {
+  if (typeof window.isSystemUser === 'function' && window.isSystemUser !== isSystemUser) {
     return window.isSystemUser();
   }
   return localStorage.getItem('systemUser') === 'true';


### PR DESCRIPTION
## Summary
- avoid recursive calls when a global `isSystemUser` hook exists

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896322a6b088328a5bfc38e42e98f4f