### PR TITLE
Retrieve auth tokens from backend

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -10,195 +10,6 @@ function documentListContainer(documentsStream, expandedStream = expandedCategor
   ], { padding: '1rem' });
 }
 
-function settingsModal(showModalStream, themeStream = currentTheme) {
-  // Retrieve the current values from localStorage or set default values
-  const storedGithubUsername = localStorage.getItem('githubUsername') || '';
-  const storedGithubTokenEncoded = localStorage.getItem('githubToken') || '';
-  const storedRepoOwner = localStorage.getItem('repoOwner') || '';
-  const storedRepoName = localStorage.getItem('repoName') || '';
-  const storedRepoPath = localStorage.getItem('repoPath') || '';
-  const storedHuggingFaceTokenEncoded = localStorage.getItem('huggingFaceToken') || '';
-
-  // Streams for form data with initial values
-  const githubUsernameStream = new Stream(storedGithubUsername);
-  const githubTokenStream = new Stream(base64Decode(storedGithubTokenEncoded));  // Decode token to display in the form
-  const repoOwnerStream = new Stream(storedRepoOwner);
-  const repoNameStream = new Stream(storedRepoName);
-  const repoPathStream = new Stream(storedRepoPath);
-  const huggingFaceTokenStream = new Stream(base64Decode(storedHuggingFaceTokenEncoded));
-
-  return conditional(showModalStream, () => {
-    // Create overlay
-    const overlay = document.createElement('div');
-    overlay.style.position = 'fixed';
-    overlay.style.top = '0';
-    overlay.style.left = '0';
-    overlay.style.width = '100vw';
-    overlay.style.height = '100vh';
-    overlay.style.backgroundColor = 'rgba(0, 0, 0, 0.5)';
-    overlay.style.display = 'flex';
-    overlay.style.alignItems = 'center';
-    overlay.style.justifyContent = 'center';
-    overlay.style.zIndex = '1000';
-
-    // Create modal container
-    const modal = document.createElement('div');
-    modal.style.padding = '1.5rem';
-    modal.style.backgroundColor = '#fff';
-    modal.style.borderRadius = '8px';
-    modal.style.boxShadow = '0 0 10px rgba(0,0,0,0.3)';
-    modal.style.width = '90%';
-    modal.style.maxWidth = '500px';
-    modal.style.position = 'relative';
-
-    // Close button
-    const closeBtn = document.createElement('button');
-    closeBtn.textContent = '✕';
-    closeBtn.style.position = 'absolute';
-    closeBtn.style.top = '0.5rem';
-    closeBtn.style.right = '0.5rem';
-    closeBtn.style.background = 'none';
-    closeBtn.style.border = 'none';
-    closeBtn.style.fontSize = '1.5rem';
-    closeBtn.style.cursor = 'pointer';
-    closeBtn.addEventListener('click', () => showModalStream.set(false));
-    modal.appendChild(closeBtn);
-
-    // Helper to build labeled fields
-    const labeledField = (labelText, inputEl, extra) => {
-      const label = reactiveText(new Stream(labelText), { tag: 'label', margin: '0 0 0.25rem 0' }, themeStream);
-      const content = extra
-        ? row([inputEl, extra], { gap: '0.5rem', align: 'center' }, themeStream)
-        : inputEl;
-      return column([label, content], { margin: '0.5rem 0', gap: '0.25rem' }, themeStream);
-    };
-
-    // GitHub Username
-    const githubUsernameInput = editText(githubUsernameStream, { margin: '0' }, themeStream);
-    const githubUsernameField = labeledField('GitHub Username', githubUsernameInput);
-
-    // GitHub Token with mask/unmask
-    const githubTokenInput = editText(githubTokenStream, { margin: '0', type: 'text' }, themeStream);
-    if (githubTokenStream.get()) githubTokenInput.value = '****';
-    const githubTokenToggleLabel = new Stream('Show');
-    const githubTokenField = labeledField('GitHub Token', githubTokenInput,
-      reactiveButton(githubTokenToggleLabel, () => {
-        if (githubTokenInput.value === '****') {
-          githubTokenInput.value = githubTokenStream.get();
-          githubTokenToggleLabel.set('Hide');
-        } else {
-          githubTokenInput.value = githubTokenStream.get() ? '****' : '';
-          githubTokenToggleLabel.set('Show');
-        }
-      }, { size: '0.8rem', padding: '0.2rem 0.5rem', margin: '0', rounded: true }, themeStream)
-    );
-
-    // Repository Owner
-    const repoOwnerInput = editText(repoOwnerStream, { margin: '0' }, themeStream);
-    const repoOwnerField = labeledField('Repository Owner', repoOwnerInput);
-
-    // Repository Name
-    const repoNameInput = editText(repoNameStream, { margin: '0' }, themeStream);
-    const repoNameField = labeledField('Repository Name', repoNameInput);
-
-    // Repository Path
-    const repoPathInput = editText(repoPathStream, { margin: '0' }, themeStream);
-    const repoPathField = labeledField('Repository Path', repoPathInput);
-
-    // Hugging Face Token with mask/unmask
-    const huggingFaceTokenInput = editText(huggingFaceTokenStream, { margin: '0', type: 'text' }, themeStream);
-    if (huggingFaceTokenStream.get()) huggingFaceTokenInput.value = '****';
-    const hfToggleLabel = new Stream('Show');
-    const huggingFaceTokenField = labeledField('Hugging Face Token', huggingFaceTokenInput,
-      reactiveButton(hfToggleLabel, () => {
-        if (huggingFaceTokenInput.value === '****') {
-          huggingFaceTokenInput.value = huggingFaceTokenStream.get();
-          hfToggleLabel.set('Hide');
-        } else {
-          huggingFaceTokenInput.value = huggingFaceTokenStream.get() ? '****' : '';
-          hfToggleLabel.set('Show');
-        }
-      }, { size: '0.8rem', padding: '0.2rem 0.5rem', margin: '0', rounded: true }, themeStream)
-    );
-
-    // Save button
-    const saveButton = (() => {
-      const isSaving = new Stream(false);
-      const saveLabel = derived(isSaving, val => val ? "Saving..." : "Save");
-
-      return reactiveButton(saveLabel, async () => {
-        if (isSaving.get()) return;
-        isSaving.set(true);
-
-        // Update global variables with current form values
-        githubUsername = githubUsernameStream.get();
-        githubToken = githubTokenStream.get();
-        repoOwner = repoOwnerStream.get();
-        repoName = repoNameStream.get();
-        repoPath = repoPathStream.get();
-        huggingFaceToken = huggingFaceTokenStream.get();
-
-        // Encode tokens before saving to localStorage
-        githubTokenEncoded = base64Encode(githubToken);
-        huggingFaceTokenEncoded = base64Encode(huggingFaceToken);
-
-        // Persist settings
-        localStorage.setItem('githubUsername', githubUsername);
-        localStorage.setItem('githubToken', githubTokenEncoded);
-        localStorage.setItem('repoOwner', repoOwner);
-        localStorage.setItem('repoName', repoName);
-        localStorage.setItem('repoPath', repoPath);
-        localStorage.setItem('huggingFaceToken', huggingFaceTokenEncoded);
-
-        // Ensure repository directories exist for new settings
-        try {
-          await ensureDirectoriesExist();
-        } catch (err) {
-          console.error('Failed to ensure directories:', err);
-        }
-
-        // Close modal after saving
-        showModalStream.set(false);
-        isSaving.set(false);
-      }, { margin: '0.5rem 0', rounded: true }, themeStream);
-    })();
-
-    const content = container([
-      githubUsernameField,
-      githubTokenField,
-      repoOwnerField,
-      repoNameField,
-      repoPathField,
-      huggingFaceTokenField,
-      saveButton
-    ], {});
-
-    modal.appendChild(content);
-    overlay.appendChild(modal);
-
-    // Close modal when clicking outside
-    overlay.addEventListener('click', (e) => {
-      if (e.target === overlay) showModalStream.set(false);
-    });
-
-    // Close modal when pressing Escape
-    const escHandler = (e) => {
-      if (e.key === 'Escape') showModalStream.set(false);
-    };
-    document.addEventListener('keydown', escHandler);
-
-    // Cleanup event listeners when modal is removed
-    const observer = new MutationObserver(() => {
-      if (!document.body.contains(overlay)) {
-        document.removeEventListener('keydown', escHandler);
-        observer.disconnect();
-      }
-    });
-    observer.observe(document.body, { childList: true, subtree: true });
-
-    return overlay;
-  });
-}
 
 // Function to check if the file already exists in the GitHub repository
 async function checkIfFileExists(filePath) {
@@ -296,11 +107,11 @@ async function deleteDocument(doc) {
       headers: { 'Authorization': `token ${githubToken}` },
     });
     if (indexRes.ok) {
-      const indexData = await indexRes.json();
-      const indexSha = indexData.sha;
-      const decoded = base64Decode(indexData.content);
-      const existing = JSON.parse(decoded).filter(d => d.id !== doc.id);
-      const updatedContent = base64Encode(JSON.stringify(existing, null, 2));
+        const indexData = await indexRes.json();
+        const indexSha = indexData.sha;
+        const decoded = atob(indexData.content);
+        const existing = JSON.parse(decoded).filter(d => d.id !== doc.id);
+        const updatedContent = btoa(JSON.stringify(existing, null, 2));
       await fetch(`https://api.github.com/repos/${repoOwner}/${repoName}/contents/${indexPath}`, {
         method: 'PUT',
         headers: {
@@ -324,23 +135,17 @@ async function deleteDocument(doc) {
   }
 }
 
-// === App entry ===
-document.addEventListener('DOMContentLoaded', async () => {
-  // Retrieve values from localStorage
-  githubUsername = localStorage.getItem('githubUsername');
-  githubTokenEncoded = localStorage.getItem('githubToken');
-  repoOwner = localStorage.getItem('repoOwner');
-  repoName = localStorage.getItem('repoName');
-  repoPath = localStorage.getItem('repoPath');
-  huggingFaceTokenEncoded = localStorage.getItem('huggingFaceToken');
+  // === App entry ===
+  document.addEventListener('DOMContentLoaded', async () => {
+    await fetchAuthTokens();
+    if (!githubToken) {
+      console.error('GitHub token not available');
+      return;
+    }
 
-  githubToken = base64Decode(githubTokenEncoded);
-  huggingFaceToken = base64Decode(huggingFaceTokenEncoded || '');
+    await ensureDirectoriesExist();
 
-  await ensureDirectoriesExist();
-
-
-  // Apply theme
+    // Apply theme
   currentTheme.subscribe(theme => applyThemeToPage(theme));
 
   // Streams
@@ -361,30 +166,20 @@ document.addEventListener('DOMContentLoaded', async () => {
     documentsStream.set([]); // Fallback: start with empty list
   }
 
-  const showModalStream = new Stream(false);
-  const userAvatarStream = new Stream('doc.webp');
-  const userAvatar = avatarDropdown(
-    userAvatarStream,
-    { width: '50px', height: '50px', rounded: true },
-    currentTheme,
-    [
-    { label: 'Profile', onClick: () => showToast('Profile clicked') },
-    { 
-  label: 'Settings', 
-      onClick: () => {
-        showModalStream.set(true);        
-      }
-    },
-    { label: 'Logout', onClick: () => showConfirmationDialog('Are you sure you want to log out?') },
-  ]);
+    const userAvatarStream = new Stream('doc.webp');
+    const userAvatar = avatarDropdown(
+      userAvatarStream,
+      { width: '50px', height: '50px', rounded: true },
+      currentTheme,
+      [
+      { label: 'Profile', onClick: () => showToast('Profile clicked') },
+      { label: 'Logout', onClick: () => showConfirmationDialog('Are you sure you want to log out?') },
+    ]);
 
-  // UI
-  document.body.appendChild(settingsModal(showModalStream, currentTheme));
- 
-
-  document.body.appendChild(
-    uploadFormContainer(documentsStream, showFormStream, knownCategoriesStream)
-  );
+    // UI
+    document.body.appendChild(
+      uploadFormContainer(documentsStream, showFormStream, knownCategoriesStream)
+    );
 
   document.body.appendChild(
     column([

--- a/js/uploadFormContainer.js
+++ b/js/uploadFormContainer.js
@@ -1,23 +1,27 @@
-// Retrieve values from localStorage
 var githubUsername = '';
-var githubTokenEncoded = '';
 var githubToken = '';
 var repoOwner = '';
 var repoName = '';
 var repoPath = '';
-var huggingFaceTokenEncoded = '';
 var huggingFaceToken = '';
 
-
-// Base64 encode function (obfuscation)
-function base64Encode(str) {
-  return btoa(unescape(encodeURIComponent(str)));
+async function fetchAuthTokens() {
+  try {
+    const response = await fetch('/api/tokens');
+    if (!response.ok) throw new Error('Failed to retrieve auth tokens');
+    const data = await response.json();
+    githubUsername = data.githubUsername || '';
+    githubToken = data.githubToken || '';
+    repoOwner = data.repoOwner || '';
+    repoName = data.repoName || '';
+    repoPath = data.repoPath || '';
+    huggingFaceToken = data.huggingFaceToken || '';
+  } catch (err) {
+    console.error('Error fetching auth tokens:', err);
+  }
 }
 
-// Base64 decode function (deobfuscation)
-function base64Decode(str) {
-  return decodeURIComponent(escape(atob(str)));
-}
+fetchAuthTokens();
 
 // === Hugging Face summarization ===
 async function summarizeText(text) {
@@ -120,7 +124,7 @@ async function createMetadataFile(slug, title, filePath, summary) {
         summary: summary || "",
     };
     console.log("Creating metadata file with:", metadata);
-    const metadataContent = base64Encode(JSON.stringify(metadata, null, 2));
+    const metadataContent = btoa(JSON.stringify(metadata, null, 2));
     const metadataFilePath = `${repoPath}/meta/${slug}.json`;
 
     await fetch(`https://api.github.com/repos/${repoOwner}/${repoName}/contents/${metadataFilePath}`, {
@@ -149,7 +153,7 @@ async function fetchDocumentIndexFromGitHub() {
   }
 
   const result = await response.json();
-  const decodedContent = base64Decode(result.content);
+  const decodedContent = atob(result.content);
   const index = JSON.parse(decodedContent);
 
   // Enrich each document with its summary from meta files
@@ -163,7 +167,7 @@ async function fetchDocumentIndexFromGitHub() {
       });
       if (metaResponse.ok) {
         const metaResult = await metaResponse.json();
-        const metaDecoded = base64Decode(metaResult.content);
+        const metaDecoded = atob(metaResult.content);
         const metaData = JSON.parse(metaDecoded);
         doc.summary = metaData.summary || '';
       } else {
@@ -189,7 +193,7 @@ async function fetchDocumentIndex() {
   });
   const data = await response.json();
   if (data.content) {
-    const decodedData = base64Decode(data.content);  // Decoding from base64
+    const decodedData = atob(data.content);  // Decoding from base64
     return JSON.parse(decodedData);
   }
   return [];
@@ -293,7 +297,7 @@ async function updateDocumentIndex(newDoc) {
     if (response.ok) {
       const data = await response.json();
       sha = data.sha; // Required for updating
-      const decoded = base64Decode(data.content);
+      const decoded = atob(data.content);
       existingIndex = JSON.parse(decoded);
     }
   } catch (err) {
@@ -309,7 +313,7 @@ async function updateDocumentIndex(newDoc) {
   }
 
   // Step 3: Upload updated index
-  const updatedContent = base64Encode(JSON.stringify(existingIndex, null, 2));
+  const updatedContent = btoa(JSON.stringify(existingIndex, null, 2));
 
   const putResponse = await fetch(`https://api.github.com/repos/${repoOwner}/${repoName}/contents/${filePath}`, {
     method: 'PUT',


### PR DESCRIPTION
## Summary
- Request GitHub and Hugging Face credentials from `/api/tokens` instead of localStorage
- Drop Base64 helper functions and use native `atob`/`btoa`
- Remove settings modal and local credential persistence

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68966a5877048328b65932a92b2feab4