### PR TITLE
refactor: centralize theme font handling

### DIFF
--- a/js/core/theme.js
+++ b/js/core/theme.js
@@ -178,13 +178,16 @@ function applyTheme(el, options = {}) {
     el.style.padding = padding;
     el.style.margin = margin;
     el.style.borderRadius = borderRadius;
-    el.style.fontFamily = theme.font;
+    el.style.fontFamily = theme.fonts.base;
     el.style.border = 'none';
 
     // 🔁 Also update body styles (global background/text)
     document.body.style.backgroundColor = theme.background;
     document.body.style.color = theme.foreground;
-    document.body.style.fontFamily = theme.font;
+    document.body.style.fontFamily = theme.fonts.base;
+    document.querySelectorAll('code, pre').forEach(codeEl => {
+      codeEl.style.fontFamily = theme.fonts.monospace;
+    });
     document.body.style.transition = 'background-color 0.3s, color 0.3s';
   });
 }
@@ -272,6 +275,10 @@ function applyThemeToPage(theme, container = document.body) {
   container.style.color = colors.foreground || '#000000';
   container.style.fontFamily = fonts.base || 'sans-serif';
   container.style.transition = 'background-color 0.3s ease, color 0.3s ease';
+
+  container.querySelectorAll('code, pre').forEach(codeEl => {
+    codeEl.style.fontFamily = fonts.monospace || 'monospace';
+  });
 
   // Optional: smooth font weight rendering
   container.style.webkitFontSmoothing = 'antialiased';

--- a/js/core/theme.test.js
+++ b/js/core/theme.test.js
@@ -1,0 +1,44 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+// Minimal DOM stub
+function createElement(tag) {
+  return {
+    tagName: tag.toUpperCase(),
+    style: {},
+    querySelectorAll() { return []; }
+  };
+}
+
+const codeEl = { tagName: 'CODE', style: {}, querySelectorAll() { return []; } };
+
+const documentStub = {
+  body: { style: {}, querySelectorAll: () => [codeEl] },
+  createElement,
+  documentElement: { style: { setProperty() {} } },
+  querySelectorAll: () => [codeEl]
+};
+
+// Load Stream class
+const streamCode = fs.readFileSync(path.join(__dirname, 'stream.js'), 'utf8');
+const Stream = new Function(`${streamCode}; return Stream;`)();
+
+// Load theme module
+const themeCode = fs.readFileSync(path.join(__dirname, 'theme.js'), 'utf8');
+const { themes, currentTheme, applyTheme } = new Function('Stream', 'document', `${themeCode}; return { themes, currentTheme, applyTheme };`)(Stream, documentStub);
+
+// Apply theme to an element to initialize styles
+const el = documentStub.createElement('div');
+applyTheme(el);
+
+// Initial theme should set base and monospace fonts
+assert.strictEqual(documentStub.body.style.fontFamily, themes.dark.fonts.base);
+assert.strictEqual(codeEl.style.fontFamily, themes.dark.fonts.monospace);
+
+// Switch theme and verify fonts update
+currentTheme.set(themes.light);
+assert.strictEqual(documentStub.body.style.fontFamily, themes.light.fonts.base);
+assert.strictEqual(codeEl.style.fontFamily, themes.light.fonts.monospace);
+
+console.log('Theme font switching works');


### PR DESCRIPTION
## Summary
- replace legacy `theme.font` usage with `theme.fonts.base`
- ensure body and code blocks adopt base/monospace fonts from theme
- add regression test verifying fonts update when theme changes

## Testing
- `node js/core/theme.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689696a01acc8328b96041274168195e