### PR TITLE
Improve network error handling with user feedback

### DIFF
--- a/js/components/elements.js
+++ b/js/components/elements.js
@@ -1045,7 +1045,7 @@ async function showFileHistoryModal(filename, themeStream = currentTheme) {
     const error = document.createElement('p');
     error.textContent = 'Error fetching history.';
     dialog.insertBefore(error, list);
-    console.error(err);
+    showToast('Error fetching history', { type: 'error' });
   }
 }
 


### PR DESCRIPTION
## Summary
- show toast notifications on network failures across upload workflow
- add fetch retries and error propagation for summarization and GitHub calls
- retry uploads and fail gracefully when directories or deletes fail

## Testing
- `node js/core/theme.test.js`

------
https://chatgpt.com/codex/tasks/task_e_6897638b6eb48328975f8f4210fc4669