### PR TITLE
Use Bearer auth for GitHub API requests

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -220,7 +220,7 @@ async function checkIfFileExists(filePath) {
   const response = await fetchWithRetry(`https://api.github.com/repos/${repoOwner}/${repoName}/contents/${filePath}`, {
     method: 'GET',
     headers: {
-      'Authorization': `token ${githubToken}`,
+      'Authorization': `Bearer ${githubToken}`,
     }
   });
 
@@ -258,7 +258,7 @@ async function ensureDirectoriesExist() {
             await fetchWithRetry(`https://api.github.com/repos/${repoOwner}/${repoName}/contents/${path}`, {
                 method: 'PUT',
                 headers: {
-                    'Authorization': `token ${githubToken}`,
+                    'Authorization': `Bearer ${githubToken}`,
                     'Content-Type': 'application/json',
                 },
                 body: JSON.stringify({
@@ -288,7 +288,7 @@ async function deleteDocument(doc) {
       await fetchWithRetry(`https://api.github.com/repos/${repoOwner}/${repoName}/contents/${filePath}`, {
         method: 'DELETE',
         headers: {
-          'Authorization': `token ${githubToken}`,
+          'Authorization': `Bearer ${githubToken}`,
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({
@@ -304,7 +304,7 @@ async function deleteDocument(doc) {
       await fetchWithRetry(`https://api.github.com/repos/${repoOwner}/${repoName}/contents/${metaPath}`, {
         method: 'DELETE',
         headers: {
-          'Authorization': `token ${githubToken}`,
+          'Authorization': `Bearer ${githubToken}`,
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({
@@ -316,7 +316,7 @@ async function deleteDocument(doc) {
 
     const indexPath = joinPath(repoPath, 'index.json');
     const indexRes = await fetchWithRetry(`https://api.github.com/repos/${repoOwner}/${repoName}/contents/${indexPath}`, {
-      headers: { 'Authorization': `token ${githubToken}` },
+      headers: { 'Authorization': `Bearer ${githubToken}` },
     });
     if (indexRes.ok) {
       const indexData = await indexRes.json();
@@ -327,7 +327,7 @@ async function deleteDocument(doc) {
       await fetchWithRetry(`https://api.github.com/repos/${repoOwner}/${repoName}/contents/${indexPath}`, {
         method: 'PUT',
         headers: {
-          'Authorization': `token ${githubToken}`,
+          'Authorization': `Bearer ${githubToken}`,
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({

--- a/public/js/components/elements.js
+++ b/public/js/components/elements.js
@@ -1027,7 +1027,7 @@ async function showFileHistoryModal(filename, themeStream = currentTheme) {
   try {
     const response = await fetch(`https://api.github.com/repos/${repoOwner}/${repoName}/commits?path=${repoPath}/${encodeURIComponent(filename)}`, {
       headers: {
-        'Authorization': `token ${githubToken}`
+        'Authorization': `Bearer ${githubToken}`
       }
     });
     const commits = await response.json();

--- a/public/js/uploadFormContainer.js
+++ b/public/js/uploadFormContainer.js
@@ -87,7 +87,7 @@ async function createMetadataFile(slug, title, filePath, summary) {
     await fetch(`https://api.github.com/repos/${repoOwner}/${repoName}/contents/${metadataFilePath}`, {
         method: 'PUT',
         headers: {
-            'Authorization': `token ${githubToken}`,
+            'Authorization': `Bearer ${githubToken}`,
             'Content-Type': 'application/json',
         },
         body: JSON.stringify({
@@ -100,7 +100,7 @@ async function createMetadataFile(slug, title, filePath, summary) {
 async function fetchDocumentIndexFromGitHub() {
   const response = await fetch(`https://api.github.com/repos/${repoOwner}/${repoName}/contents/${repoPath}/index.json`, {
     headers: {
-      'Authorization': `token ${githubToken}`
+      'Authorization': `Bearer ${githubToken}`
     }
   });
 
@@ -119,7 +119,7 @@ async function fetchDocumentIndexFromGitHub() {
 async function fetchDocumentIndex() {
   const response = await fetch(`https://api.github.com/repos/${repoOwner}/${repoName}/contents/${repoPath}/index.json`, {
     headers: {
-      'Authorization': `token ${githubToken}`,
+      'Authorization': `Bearer ${githubToken}`,
     }
   });
   const data = await response.json();
@@ -147,10 +147,10 @@ async function uploadFileToGitHub(file, slug) {
     }
 
     // Make the request to GitHub API
-    const response = await fetch(`https://api.github.com/repos/${repoOwner}/${repoName}/contents/${filePath}`, {
+  const response = await fetch(`https://api.github.com/repos/${repoOwner}/${repoName}/contents/${filePath}`, {
       method: 'PUT',
       headers: {
-        'Authorization': `token ${githubToken}`,
+        'Authorization': `Bearer ${githubToken}`,
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({
@@ -198,7 +198,7 @@ async function updateDocumentIndex(newDoc) {
   try {
     const response = await fetch(`https://api.github.com/repos/${repoOwner}/${repoName}/contents/${filePath}`, {
       headers: {
-        'Authorization': `token ${githubToken}`
+        'Authorization': `Bearer ${githubToken}`
       }
     });
 
@@ -226,7 +226,7 @@ async function updateDocumentIndex(newDoc) {
   const putResponse = await fetch(`https://api.github.com/repos/${repoOwner}/${repoName}/contents/${filePath}`, {
     method: 'PUT',
     headers: {
-      'Authorization': `token ${githubToken}`,
+      'Authorization': `Bearer ${githubToken}`,
       'Content-Type': 'application/json',
     },
     body: JSON.stringify({


### PR DESCRIPTION
## Summary
- switch GitHub API requests to use `Bearer` token header
- ensure upload and deletion operations consistently send `Bearer` auth

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689789f3b38c83289e6b68e188642bd9