### PR TITLE
Refresh index after saving GitHub settings

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -166,6 +166,18 @@ function settingsModal(showModalStream, themeStream = currentTheme) {
 
         // Close modal after saving
         showModalStream.set(false);
+
+        // Fetch updated index with new credentials
+        if (window.documentsStream) {
+          try {
+            const indexData = await fetchDocumentIndexFromGitHub();
+            window.documentsStream.set(indexData);
+          } catch (err) {
+            console.warn('Using empty index as fallback.', err);
+            window.documentsStream.set([]);
+          }
+        }
+
         isSaving.set(false);
       }, { margin: '0.5rem 0', rounded: true }, themeStream);
     })();


### PR DESCRIPTION
## Summary
- Re-fetch document index when GitHub settings are saved to update the document list

## Testing
- `node js/core/theme.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6898d3348e908328865c948dbe24fcd6