### PR TITLE
Add tokenization and token-based search

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -16,6 +16,13 @@ A lightweight reactive UI micro-framework in plain JavaScript — inspired by Sv
 * 📝 **Reactive components**: Use `reactiveText` and `editText` to bind UI to state.
 * 🧩 **JSON-bound streams**: Bind `Stream` instances directly to keys in a JSON object (e.g. fetched from storage or API).
 * 📄 **Document summarization**: Generates summaries for text, PDF, and Word files via Hugging Face models.
+* 🔍 **Tokenized search**: Text is lowercased and split into word tokens using `/\w+/g` for exact-match querying.
+
+---
+
+## 🔎 Search Tokenization
+
+During `build-index.js` the text from all metadata fields is concatenated, lowercased and split into word tokens using the regular expression `/\w+/g`. Search queries are tokenized the same way and a document matches only when **all** query tokens are present in its token list. The `\w` class targets ASCII letters, numbers and underscores, so languages requiring different word boundaries may need a custom tokenizer.
 
 ---
 

--- a/build-index.js
+++ b/build-index.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const tokenize = require('./js/core/tokenize');
 
 const META_DIR = path.join(__dirname, 'meta');
 const INDEX_FILE = path.join(__dirname, 'index.json');
@@ -25,6 +26,10 @@ function readMetadata() {
       if (data.date && !isValidDate(data.date)) {
         throw new Error('Invalid date');
       }
+      const textContent = Object.values(data)
+        .filter(v => typeof v === 'string')
+        .join(' ');
+      data.tokens = Array.from(new Set(tokenize(textContent)));
       items.push(data);
     } catch (err) {
       console.error(`Skipping ${file}: ${err.message}`);

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
 
   <!-- 👇 Load in correct order -->
   <script src="js/core/theme.js"></script>  <!-- defines `currentTheme` + applyTheme -->
+  <script src="js/core/tokenize.js"></script>
 
   <!-- The rest -->
   <script src="js/components/layout.js"></script>

--- a/js/components/elements.js
+++ b/js/components/elements.js
@@ -612,14 +612,15 @@ wrapper.appendChild(contentWrapper);
     (docs, expanded, theme, search, colWidths) => {
       contentWrapper.innerHTML = '';
 
-      const lowerSearch = search.trim().toLowerCase();
-      const isSearching = lowerSearch.length > 0;
+      const queryTokens = tokenize(search);
+      const isSearching = queryTokens.length > 0;
 
-      const filteredDocs = docs.filter(doc =>
-        keys.some(key =>
-          (doc[key]?.toString().toLowerCase().includes(lowerSearch))
-        )
-      );
+      const filteredDocs = isSearching
+        ? docs.filter(doc => {
+            const docTokens = doc.tokens || [];
+            return queryTokens.every(t => docTokens.includes(t));
+          })
+        : docs;
 
       const grouped = {};
       for (const doc of filteredDocs) {
@@ -1617,12 +1618,15 @@ function groupedDocumentCards(documentsStream, expandedStream, themeStream = cur
     (docs, expanded, theme, search) => {
       contentWrapper.innerHTML = '';
 
-      const lowerSearch = search.trim().toLowerCase();
-      const isSearching = lowerSearch.length > 0;
+      const queryTokens = tokenize(search);
+      const isSearching = queryTokens.length > 0;
 
-      const filteredDocs = docs.filter(doc =>
-        keys.some(key => (doc[key]?.toString().toLowerCase().includes(lowerSearch)))
-      );
+      const filteredDocs = isSearching
+        ? docs.filter(doc => {
+            const docTokens = doc.tokens || [];
+            return queryTokens.every(t => docTokens.includes(t));
+          })
+        : docs;
 
       const grouped = {};
       for (const doc of filteredDocs) {

--- a/js/core/tokenize.js
+++ b/js/core/tokenize.js
@@ -1,0 +1,9 @@
+function tokenize(text = '') {
+  return text.toLowerCase().match(/\w+/g) || [];
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = tokenize;
+} else {
+  window.tokenize = tokenize;
+}


### PR DESCRIPTION
## Summary
- add reusable `tokenize` helper for lowercasing and splitting text into word tokens
- build index files with precomputed token lists for metadata
- match documents during search only when all query tokens are present

## Testing
- `node js/core/theme.test.js`
- `node build-index.js && cat index.json`


------
https://chatgpt.com/codex/tasks/task_e_6898f40502fc83288de9edca1848fccd