### PR TITLE
feat: remember last used upload category

### DIFF
--- a/js/components/elements.js
+++ b/js/components/elements.js
@@ -885,6 +885,7 @@ function editableDropdown(valueStream, optionsStream, themeStream = currentTheme
       o.textContent = opt;
       select.appendChild(o);
     }
+    select.value = valueStream.get() || '';
   }
 
   // Update value stream on selection or manual input
@@ -898,6 +899,12 @@ function editableDropdown(valueStream, optionsStream, themeStream = currentTheme
 
   // React to options stream
   optionsStream.subscribe(updateOptions);
+
+  // Reflect external changes in the UI
+  valueStream.subscribe(val => {
+    select.value = val;
+    input.value = val;
+  });
 
   // Apply theme styles
   themeStream.subscribe(theme => {

--- a/js/uploadFormContainer.js
+++ b/js/uploadFormContainer.js
@@ -363,7 +363,7 @@ function uploadFormContainer(documentsStream, showFormStream, knownCategoriesStr
   const descriptionStream = new Stream('');
   const docStatusStream = new Stream('');
   const fileStream = new Stream(null);
-  const categoryStream = new Stream('');
+  const categoryStream = new Stream(localStorage.getItem('lastUsedCategory') || '');
   const metaStream = new Stream('');
 
   // Streams for upload progress/status
@@ -569,6 +569,7 @@ function uploadFormContainer(documentsStream, showFormStream, knownCategoriesStr
           }
 
           documentsStream.set([...docs]);
+          localStorage.setItem('lastUsedCategory', newDoc.category);
           showFormStream.set(false);
         } catch (err) {
           statusStream.set('');


### PR DESCRIPTION
## Summary
- persist the last selected category in localStorage and reuse it for new uploads
- ensure category dropdown and text input reflect externally supplied values

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899148fa5588328848b1955ffe31c64