### PR TITLE
Add document metrics header

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -395,6 +395,20 @@ document.addEventListener('DOMContentLoaded', async () => {
     return Array.from(set).sort();
   });
 
+  const metricsStream = derived(documentsStream, docs => {
+    const totalDocs = docs.length;
+    const categories = new Set(docs.map(doc => doc.category?.trim()).filter(Boolean));
+    const latest = docs.reduce((latest, doc) => {
+      const date = doc.lastUpdated ? new Date(doc.lastUpdated) : null;
+      return date && (!latest || date > latest) ? date : latest;
+    }, null);
+    return {
+      totalDocs,
+      uniqueCategories: categories.size,
+      latestUpdate: latest ? latest.toISOString().split('T')[0] : 'N/A'
+    };
+  });
+
   if (!missingConfig) {
     // 🟡 Fetch index.json and hydrate the stream
     try {
@@ -465,6 +479,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   document.body.appendChild(
     column([
+      headerContainer(headerTitleStream, metricsStream, currentTheme),
       container(
         row([
           userAvatar,

--- a/js/components/elements.js
+++ b/js/components/elements.js
@@ -494,18 +494,27 @@ function conditional(showStream, childElementFn) {
   return wrapper;
 }
 
-function headerContainer(titleStream) {
+function headerContainer(titleStream, metricsStream, themeStream = currentTheme) {
+  const docCountStream = derived(metricsStream, m => `Documents: ${m.totalDocs}`);
+  const categoryCountStream = derived(metricsStream, m => `Categories: ${m.uniqueCategories}`);
+  const latestUpdateStream = derived(metricsStream, m => `Latest Update: ${m.latestUpdate}`);
+
   return container([
     reactiveText(titleStream, {
       size: '2rem',
       weight: 'bold',
-      margin: '1rem 0',
+      margin: '0 0 0.5rem 0',
       align: 'center'
-    })
+    }, themeStream),
+    row([
+      reactiveText(docCountStream, { margin: '0' }, themeStream),
+      reactiveText(categoryCountStream, { margin: '0' }, themeStream),
+      reactiveText(latestUpdateStream, { margin: '0' }, themeStream)
+    ], { justify: 'center', gap: '1rem' }, themeStream)
   ], {
     padding: '1rem',
     align: 'center'
-  });
+  }, themeStream);
 }
 
 


### PR DESCRIPTION
## Summary
- derive metrics from loaded documents including counts and latest update
- display metrics in header above controls for quick overview

## Testing
- `node js/core/theme.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689922f511248328a9ca5d6a6ddb97ca